### PR TITLE
Implement Basic Merge Policy

### DIFF
--- a/feather/src/storage/FileSystemStorage.java
+++ b/feather/src/storage/FileSystemStorage.java
@@ -147,4 +147,8 @@ public class FileSystemStorage extends Storage {
         throw new UnsupportedOperationException(
                 "Direct file creation is no longer supported. Use createSegmentFileWriter() instead.");
     }
+
+    public Path getRootPath() {
+        return rootPath;
+    }
 }

--- a/feather/src/storage/merge/MergePolicy.java
+++ b/feather/src/storage/merge/MergePolicy.java
@@ -1,0 +1,48 @@
+package storage.merge;
+
+import storage.file.SegmentMetadata;
+import java.util.List;
+
+public abstract class MergePolicy {
+    // default config values
+
+    protected static final int DEFAULT_MAX_MERGE_AT_ONCE = 10;
+    protected static final int MIN_SEGMENT_DOCS = 1000;
+    protected static final int MAX_SEGMENT_DOCS = 1_000_000;
+
+    // a limitation for segments to get merged at a time
+    private final int maxMergeAtOnce;
+    private final int maxSegmentDocs;
+
+    protected MergePolicy() {
+        this(DEFAULT_MAX_MERGE_AT_ONCE, MAX_SEGMENT_DOCS);
+    }
+
+    protected MergePolicy(int maxMergeAtOnce, int maxSegmentDocs) {
+        validateSettings(maxMergeAtOnce, maxSegmentDocs);
+        this.maxMergeAtOnce = maxMergeAtOnce;
+        this.maxSegmentDocs = maxSegmentDocs;
+    }
+
+    private void validateSettings(int maxMergeAtOnce, int maxSegmentDocs) {
+        if (maxMergeAtOnce < 2) {
+            throw new IllegalArgumentException("maxMergeAtOnce must be >= 2");
+        }
+        if (maxSegmentDocs <= MIN_SEGMENT_DOCS) {
+            throw new IllegalArgumentException(
+                    "maxSegmentDocs must be > " + MIN_SEGMENT_DOCS);
+        }
+    }
+
+    public abstract MergeSpec findMerges(List<SegmentMetadata> segments);
+
+    protected boolean exceedsMaxDocs(List<SegmentMetadata> segments) {
+        return segments.stream()
+                .mapToInt(SegmentMetadata::getDocumentCount)
+                .sum() > maxSegmentDocs;
+    }
+
+    // Getters
+    protected int getMaxMergeAtOnce() { return maxMergeAtOnce; }
+    protected int getMaxSegmentDocs() { return maxSegmentDocs; }
+}

--- a/feather/src/storage/merge/MergeSpec.java
+++ b/feather/src/storage/merge/MergeSpec.java
@@ -1,0 +1,33 @@
+package storage.merge;
+
+import storage.file.SegmentMetadata;
+import java.util.List;
+import java.util.Collections;
+
+public class MergeSpec {
+    private final List<SegmentMetadata> segments;
+    private final String mergedName;
+
+    public MergeSpec(List<SegmentMetadata> segments) {
+        if (segments == null || segments.size() < 2) {
+            throw new IllegalArgumentException("Must provide at least 2 segments to merge");
+        }
+
+        this.segments = List.of(segments.toArray(SegmentMetadata[]::new));
+        this.mergedName = generateMergedName(segments);
+    }
+
+    private String generateMergedName(List<SegmentMetadata> segments) {
+        return String.format("m_%d_%d",
+                segments.size(),
+                System.currentTimeMillis());
+    }
+
+    public List<SegmentMetadata> getSegments() {
+        return segments;
+    }
+
+    public String getMergedName() {
+        return mergedName;
+    }
+}


### PR DESCRIPTION


# Implement Basic Merge Policy

## Overview
Implemented basic merge policy structure for segment merging operations. This provides the foundation for implementing different merge strategies.

## Key Changes

### 1. MergePolicy Abstract Class
- Added abstract base class for merge policies
- Implemented configurable merge limitations (not fixed yet)
  - Maximum segments to merge at once (default: 10)
  - Minimum segment documents (1,000)
  - Maximum segment documents (1,000,000)
- Added validation for merge settings
- Provided abstract `findMerges` method for specific policy implementations

### 2. MergeSpec Implementation
- Added immutable merge specification class
- Implemented thread-safe segment list handling using `List.of`
- Added merged segment name generation with format: `m_<count>_<timestamp>`
- Added validation for merge requirements (minimum 2 segments)

### 3. Storage Enhancement
- Added `getRootPath()` method to `FileSystemStorage` for segment path access
- `rootPath` would be the path for a certain directory path for a set of segment files

## Example Usage
```java
// Create merge policy with custom settings
// Sub-classes of MergePolicy should override and describe the `findMerges()` 
MergePolicy policy = new SimpleMergePolicy(5, 500_000);

// Find segments to merge
// findMerge() is an abstract method 
MergeSpec spec = policy.findMerges(segments);

// Get merge details
List<SegmentMetadata> toMerge = spec.getSegments();
String newSegmentName = spec.getMergedName();
```

## Next Steps

1. Add segment processing and merging implementation with a `TermBuffer` implementation
2. Implement concrete merge policies (e.g., `SimpleMergePolicy`)
3. Implement segment deletion after successful merges

This PR provides the foundation for segment merging operations. The actual merge implementation will be added in a subsequent PR in a row.