### PR TITLE
Improve Token Handling with Stream Type

### DIFF
--- a/feather/src/core/analysis/FeatherAnalyzer.java
+++ b/feather/src/core/analysis/FeatherAnalyzer.java
@@ -1,7 +1,7 @@
 package core.analysis;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 public interface FeatherAnalyzer {
-    List<FeatherToken> analyze(String text);
+    Stream<FeatherToken> analyze(String text);
 }

--- a/feather/src/core/analysis/FeatherToken.java
+++ b/feather/src/core/analysis/FeatherToken.java
@@ -1,17 +1,4 @@
 package core.analysis;
 
-public class FeatherToken {
-    private final String term;
-    private final int startOffset;
-    private final int endOffset;
-
-    public FeatherToken(String term, int startOffset, int endOffset) {
-        this.term = term;
-        this.startOffset = startOffset;
-        this.endOffset = endOffset;
-    }
-
-    public String term() { return term; }
-    public int startOffset() { return startOffset; }
-    public int endOffset() { return endOffset; }
+public record FeatherToken(String term, int startOffset, int endOffset) {
 }

--- a/feather/src/core/analysis/LuceneAnalyzerAdapter.java
+++ b/feather/src/core/analysis/LuceneAnalyzerAdapter.java
@@ -6,8 +6,9 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.UncheckedIOException;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 public class LuceneAnalyzerAdapter implements FeatherAnalyzer {
 
@@ -18,20 +19,35 @@ public class LuceneAnalyzerAdapter implements FeatherAnalyzer {
     }
 
     @Override
-    public List<FeatherToken> analyze(String text) {
-        List<FeatherToken> tokens = new ArrayList<>();
-        try (TokenStream stream = luceneAnalyzer.tokenStream(null, text)) {
-            CharTermAttribute termAttr = stream.addAttribute(CharTermAttribute.class);
-            OffsetAttribute offsetAttr = stream.addAttribute(OffsetAttribute.class);
-            stream.reset();
-            while (stream.incrementToken()) {
-                tokens.add(new FeatherToken(termAttr.toString(), offsetAttr.startOffset(), offsetAttr.endOffset()));
-            }
-            stream.end();
+    public Stream<FeatherToken> analyze(String text) {
+        try {
+            TokenStream tokenStream = luceneAnalyzer.tokenStream(null, text);
+            tokenStream.reset();
+
+            CharTermAttribute termAttr = tokenStream.getAttribute(CharTermAttribute.class);
+            OffsetAttribute offsetAttr = tokenStream.getAttribute(OffsetAttribute.class);
+
+            return Stream.generate(() -> {
+                        try {
+                            if (tokenStream.incrementToken()) {
+                                return new FeatherToken(termAttr.toString(), offsetAttr.startOffset(), offsetAttr.endOffset());
+                            }
+                            return null;
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    })
+                    .takeWhile(Objects::nonNull)
+                    .onClose(() -> {
+                        try {
+                            tokenStream.end();
+                            tokenStream.close();
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
         } catch (IOException e) {
-            throw new RuntimeException("Lucene analysis failed", e);
+            throw new UncheckedIOException("Failed to create TokenStream from analyzer", e);
         }
-        return tokens;
     }
 }
-

--- a/feather/src/core/index/IndexWriter.java
+++ b/feather/src/core/index/IndexWriter.java
@@ -38,52 +38,38 @@ public class IndexWriter {
             throw new IllegalStateException("FeatherAnalyzer is not configured in IndexWriterConfig.");
         }
 
-        List<Map<String, List<FeatherToken>>> analyzedDocumentTokens = new ArrayList<>();
-        List<Integer> documentIds = new ArrayList<>();
-
-        for (Document doc : documentBuffer) {
-            documentIds.add(doc.getId());
-            Map<String, Object> fields = doc.getFields();
-            Map<String, List<FeatherToken>> docTokens = new java.util.HashMap<>();
-            for (Map.Entry<String, Object> entry : fields.entrySet()) {
-                String fieldName = entry.getKey();
-                Object fieldValue = entry.getValue();
-
-                if (fieldValue instanceof String) {
-                    List<FeatherToken> tokens = analyzer.analyze((String) fieldValue);
-                    docTokens.put(fieldName, tokens);
-                }
-                // TODO: Handle other field types (Numeric, Binary) if they need analysis or special processing
-            }
-            analyzedDocumentTokens.add(docTokens);
-        }
-
         String segmentName = "segment_" + (segmentCounter++);
         System.out.println("Generated segment name: " + segmentName);
 
         // Map: term -> documentId -> list of positions
         Map<String, Map<Integer, List<Integer>>> postingLists = new HashMap<>();
 
-        for (int i = 0; i < analyzedDocumentTokens.size(); i++) {
-            int docId = documentIds.get(i);
-            Map<String, List<FeatherToken>> docTokens = analyzedDocumentTokens.get(i);
+        // Process documents one by one, and their token streams directly
+        for (Document doc : documentBuffer) {
+            int docId = doc.getId();
+            Map<String, Object> fields = doc.getFields();
 
-            for (Map.Entry<String, List<FeatherToken>> fieldEntry : docTokens.entrySet()) {
-                String fieldName = fieldEntry.getKey();
-                List<FeatherToken> tokens = fieldEntry.getValue();
+            for (Map.Entry<String, Object> entry : fields.entrySet()) {
+                String fieldName = entry.getKey();
+                Object fieldValue = entry.getValue();
 
-                for (FeatherToken token : tokens) {
-                    String term = token.term();
-                    // Combine field name and term for unique identification in the dictionary
-                    String fullTerm = fieldName + ":" + term;
+                if (fieldValue instanceof String) {
+                    // Get the stream and process it directly
+                    analyzer.analyze((String) fieldValue).forEach(token -> {
+                        String term = token.term();
+                        // Combine field name and term for unique identification in the dictionary
+                        String fullTerm = fieldName + ":" + term;
 
-                    postingLists
-                        .computeIfAbsent(fullTerm, k -> new HashMap<>())
-                        .computeIfAbsent(docId, k -> new ArrayList<>())
-                        .add(token.startOffset()); // Using startOffset as position for now
+                        postingLists
+                            .computeIfAbsent(fullTerm, k -> new HashMap<>())
+                            .computeIfAbsent(docId, k -> new ArrayList<>())
+                            .add(token.startOffset()); // Using startOffset as position for now
+                    });
                 }
+                // TODO: Handle other field types (Numeric, Binary) if they need analysis or special processing
             }
         }
+
         System.out.println("Built in-memory posting lists for " + postingLists.size() + " unique terms.");
 
 

--- a/feather/test/LuceneAnalyzerAdapterTest.java
+++ b/feather/test/LuceneAnalyzerAdapterTest.java
@@ -1,0 +1,121 @@
+import core.analysis.FeatherAnalyzer;
+import core.analysis.FeatherToken;
+import core.analysis.LuceneAnalyzerAdapter;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LuceneAnalyzerAdapterTest {
+
+    private FeatherAnalyzer featherAnalyzer;
+
+    @BeforeEach
+    // StandardAnalyzer does not remove common stop words!
+    void setUp() {
+        featherAnalyzer = new LuceneAnalyzerAdapter(new StandardAnalyzer());
+    }
+
+    @Test
+    void analyze_SimpleText_ReturnsCorrectTokens() {
+        // Given
+        String text = "Hello World";
+
+        // When
+        List<FeatherToken> tokens = featherAnalyzer.analyze(text).collect(Collectors.toList());
+
+        // Then
+        assertNotNull(tokens);
+        assertEquals(2, tokens.size());
+        assertEquals(new FeatherToken("hello", 0, 5), tokens.get(0));
+        assertEquals(new FeatherToken("world", 6, 11), tokens.get(1));
+    }
+
+    @Test
+    void analyze_TextWithMultipleTokens_ReturnsCorrectTokens() {
+        // Given
+        String text = "This is a test sentence.";
+
+        // When
+        List<FeatherToken> tokens = featherAnalyzer.analyze(text).collect(Collectors.toList());
+
+        // Then
+        assertNotNull(tokens);
+        assertEquals(5, tokens.size());
+        assertEquals(new FeatherToken("this", 0, 4), tokens.get(0));
+        assertEquals(new FeatherToken("is", 5, 7), tokens.get(1));
+        assertEquals(new FeatherToken("sentence", 15, 23), tokens.get(4));
+    }
+
+    @Test
+    void analyze_EmptyString_ReturnsEmptyList() {
+        // Given
+        String text = "";
+
+        // When
+        List<FeatherToken> tokens = featherAnalyzer.analyze(text).collect(Collectors.toList());
+
+        // Then
+        assertNotNull(tokens);
+        assertTrue(tokens.isEmpty());
+    }
+
+    @Test
+    void analyze_TextWithSpecialCharacters_HandlesCorrectly() {
+        // Given
+        // characters like `-`, `.`, `( )` get removed on StandardAnalyzer
+        String text = "apple-pie, banana. (cherry)";
+
+        // When
+        List<FeatherToken> tokens = featherAnalyzer.analyze(text).collect(Collectors.toList());
+        System.out.println(Arrays.toString(tokens.toArray()));
+
+        // Then
+        assertNotNull(tokens);
+
+        // apple, pie, banana, cherry
+        assertEquals(4, tokens.size());
+        assertEquals(new FeatherToken("apple", 0, 5), tokens.get(0));
+        assertEquals(new FeatherToken("banana", 11, 17), tokens.get(2));
+        assertEquals(new FeatherToken("cherry", 20, 26), tokens.get(3));
+    }
+
+    @Test
+    void analyze_OffsetsAreCorrect() {
+        // Given
+        String text = "  leading and trailing spaces  ";
+
+        // When
+        List<FeatherToken> tokens = featherAnalyzer.analyze(text).collect(Collectors.toList());
+
+        // Then
+        assertNotNull(tokens);
+        assertEquals(4, tokens.size());
+        assertEquals(new FeatherToken("leading", 2, 9), tokens.get(0));
+        assertEquals(new FeatherToken("and", 10, 13), tokens.get(1));
+        assertEquals(new FeatherToken("trailing", 14, 22), tokens.get(2));
+        assertEquals(new FeatherToken("spaces", 23, 29), tokens.get(3));
+    }
+
+    @Test
+    void analyze_KoreanText_ReturnsCorrectTokens() {
+        // Given
+        String text = "안녕하세요 환영합니다";
+
+        // When
+        List<FeatherToken> tokens = featherAnalyzer.analyze(text).collect(Collectors.toList());
+
+        // Then
+        assertNotNull(tokens);
+        // StandardAnalyzer treats Korean characters as a single token or breaks them by whitespace
+        // It might not produce linguistically correct tokens for Korean, but we test its behavior.
+        assertEquals(2, tokens.size());
+        assertEquals(new FeatherToken("안녕하세요", 0, 5), tokens.get(0));
+        assertEquals(new FeatherToken("환영합니다", 6, 11), tokens.get(1));
+    }
+}


### PR DESCRIPTION
# Improve Token Handling with Stream Type

## Overview

This pull request refactors the core analysis pipeline to use Java Streams, transitioning from eagerly-collected `List`s to lazily-processed `Stream`s. This change improves memory efficiency, readability, and modernizes the codebase by leveraging Java 17 features.

## Key Changes

- **`FeatherAnalyzer` Interface:** The `analyze` method signature has been updated to return a `Stream<FeatherToken>` instead of a `List<FeatherToken>`. This is the core change that enables lazy processing of tokens throughout the indexing pipeline.

- **`LuceneAnalyzerAdapter`:**
    - The adapter has been completely refactored to implement the new `Stream`-based interface.
    - It now uses `Stream.generate` combined with `takeWhile` to convert Lucene's `TokenStream` into a `Stream<FeatherToken>`. This approach is more concise, readable, and idiomatic for a modern Java 17 codebase compared to the previous manual iteration.

- **`IndexWriter`:**
    - The `IndexWriter` has been updated to consume the `Stream<FeatherToken>` directly from the analyzer.
    - This avoids collecting all tokens for a document into an intermediate list, reducing memory usage and allowing the writer to process tokens as they are being generated.

## Tests

- A new test suite, `LuceneAnalyzerAdapterTest.java`, has been added to provide comprehensive unit tests for the refactored `LuceneAnalyzerAdapter`.
- The tests cover a wide range of scenarios to ensure the adapter's correctness, including:
    - Simple and multi-token text.
    - Empty strings.
    - Text with special characters.
    - Verification of correct token offsets.
    - Basic handling of Korean text.