### PR TITLE
Implement IndexWriter flush() and commit()

### DIFF
--- a/feather/src/core/index/IndexWriter.java
+++ b/feather/src/core/index/IndexWriter.java
@@ -10,7 +10,7 @@ import java.util.HashMap; // Added import
 import java.util.List;
 import java.util.Map;
 
-public class IndexWriter {
+public class IndexWriter implements Closeable {
 
     private final Storage storage;
     private final IndexWriterConfig config;
@@ -91,6 +91,7 @@ public class IndexWriter {
         // TODO: Persist segment metadata (segments_N file).
     }
 
+    @Override
     public void close() throws IOException {
         try {
             commit();

--- a/feather/src/core/index/IndexWriter.java
+++ b/feather/src/core/index/IndexWriter.java
@@ -33,6 +33,11 @@ public class IndexWriter {
     private void flush() throws IOException {
         System.out.println("Flushing " + documentBuffer.size() + " documents.");
 
+        if (documentBuffer.isEmpty()) {
+            System.out.println("Document Buffer is empty, nothing to flush.");
+            return;
+        }
+
         FeatherAnalyzer analyzer = config.getAnalyzer();
         if (analyzer == null) {
             throw new IllegalStateException("FeatherAnalyzer is not configured in IndexWriterConfig.");

--- a/feather/src/core/index/Segments.java
+++ b/feather/src/core/index/Segments.java
@@ -1,0 +1,129 @@
+package core.index;
+
+import storage.SegmentInfo;
+import storage.Storage;
+import storage.FileSystemStorage;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+    Segments is
+ */
+public class Segments {
+    public static final String SEGMENTS_GEN = "segments.gen";
+
+    private final List<SegmentInfo> segments;
+    private long generation; // The version of the segments file (the _N in segments_N)
+
+    public Segments() {
+        this.segments = new ArrayList<>();
+        this.generation = -1;
+    }
+
+    private Segments(long generation, List<SegmentInfo> segments) {
+        this.generation = generation;
+        this.segments = segments;
+    }
+
+    public List<SegmentInfo> getSegments() {
+        return new ArrayList<>(segments);
+    }
+
+    public void addSegment(SegmentInfo segment) {
+        this.segments.add(segment);
+    }
+
+    public int size() {
+        return segments.size();
+    }
+
+    /**
+     * Writes the current list of segments to a new segments file.
+     * @param storage The storage to write to.
+     * @throws IOException If an I/O error occurs.
+     */
+    public void write(Storage storage) throws IOException {
+        long nextGeneration = generation + 1;
+        String segmentsFileName = "segments_" + nextGeneration;
+        Path directory = ((FileSystemStorage) storage).getRootPath();
+        Path tempSegmentsFile = Files.createTempFile(directory, "pending_segments_", ".tmp");
+
+        // 1. Serialize segments list to a byte array
+        byte[] data = serializeSegments(nextGeneration);
+
+        // 2. Write data to a temporary file
+        Files.write(tempSegmentsFile, data);
+
+        // 3. Atomically rename the temporary file to the new segments file
+        Files.move(tempSegmentsFile, directory.resolve(segmentsFileName), StandardCopyOption.ATOMIC_MOVE);
+
+        // 4. Atomically update the generation file
+        Path tempGenFile = Files.createTempFile(directory, "pending_gen_", ".tmp");
+        Files.writeString(tempGenFile, String.valueOf(nextGeneration));
+        Files.move(tempGenFile, directory.resolve(SEGMENTS_GEN), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+
+        System.out.println("Successfully wrote " + segmentsFileName + " and updated " + SEGMENTS_GEN);
+
+        // 5. TODO: Clean up old, unreferenced segments_N files
+
+        this.generation = nextGeneration;
+    }
+
+    private byte[] serializeSegments(long currentGeneration) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeLong(currentGeneration); // Write the generation number
+            oos.writeInt(this.segments.size());
+            for (SegmentInfo segment : segments) {
+                oos.writeObject(segment);
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Reads the most recent segments file from the storage.
+     * @param storage The storage to read from.
+     * @throws IOException If an I/O error occurs.
+     */
+    public static Segments readLatest(Storage storage) throws IOException {
+        Path directory = ((FileSystemStorage) storage).getRootPath();
+        Path genFile = directory.resolve(SEGMENTS_GEN);
+
+        if (!Files.exists(genFile)) {
+            // No segments file yet, this is a new index
+            return new Segments();
+        }
+
+        long latestGeneration = Long.parseLong(Files.readString(genFile));
+        String segmentsFileName = "segments_" + latestGeneration;
+        Path segmentsFile = directory.resolve(segmentsFileName);
+
+        if (!Files.exists(segmentsFile)) {
+            throw new IOException("Segments file not found for generation: " + latestGeneration);
+        }
+
+        byte[] data = Files.readAllBytes(segmentsFile);
+        return deserializeSegments(data);
+    }
+
+    private static Segments deserializeSegments(byte[] data) throws IOException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+            long generation = ois.readLong();
+            int size = ois.readInt();
+            List<SegmentInfo> segments = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                segments.add((SegmentInfo) ois.readObject());
+            }
+            return new Segments(generation, segments);
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Failed to deserialize Segments file, class not found.", e);
+        }
+    }
+}

--- a/feather/src/storage/FileSystemStorage.java
+++ b/feather/src/storage/FileSystemStorage.java
@@ -91,6 +91,7 @@ public class FileSystemStorage extends Storage {
      * @return A SegmentFileWriter instance for writing to the file
      * @throws IOException If an I/O error occurs
      */
+    @Override
     public SegmentFileWriter createFileWriter(String name, FileType type) throws IOException {
         ensureOpen();
         validateFileName(name);
@@ -239,6 +240,7 @@ public class FileSystemStorage extends Storage {
     /**
      * Creates a MetaFileWriter with the provided metadata.
      */
+    @Override
     public MetaFileWriter createMetaFileWriter(String name, SegmentMetadata metadata) throws IOException {
         ensureOpen();
         validateFileName(name);

--- a/feather/src/storage/Storage.java
+++ b/feather/src/storage/Storage.java
@@ -2,6 +2,9 @@ package storage;
 
 import storage.file.FileType;
 import storage.file.SegmentFile;
+import storage.file.SegmentMetadata;
+import storage.writer.MetaFileWriter;
+import storage.writer.SegmentFileWriter;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -20,6 +23,8 @@ public abstract class Storage implements Closeable {
     public abstract long fileLength(String name) throws IOException;
     public abstract boolean fileExists(String name) throws IOException;
     public abstract SegmentFile createFile(String name, FileType type) throws IOException;
+    public abstract SegmentFileWriter createFileWriter(String name, FileType type) throws IOException;
+    public abstract MetaFileWriter createMetaFileWriter(String name, SegmentMetadata metadata) throws IOException;
     public abstract SegmentFile openFile(String name) throws IOException;
     public abstract void deleteFile(String name) throws IOException;
     public abstract String[] listFiles() throws IOException;

--- a/feather/test/IndexWriterTest.java
+++ b/feather/test/IndexWriterTest.java
@@ -1,0 +1,219 @@
+import core.analysis.FeatherAnalyzer;
+import core.analysis.LuceneAnalyzerAdapter;
+import core.index.IndexWriter;
+import core.index.IndexWriterConfig;
+import core.index.Segments;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import storage.FileSystemStorage;
+import storage.Storage;
+import storage.file.Document;
+import storage.file.FileType;
+import storage.file.SegmentMetadata;
+import storage.merge.MergePolicy;
+import storage.merge.MergeSpec;
+import storage.writer.SegmentFileWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IndexWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Storage storage;
+    private FeatherAnalyzer analyzer;
+    private IndexWriterConfig config;
+    private IndexWriter writer;
+    private MergePolicy mergePolicy;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        storage = new FileSystemStorage(tempDir);
+        analyzer = new LuceneAnalyzerAdapter(new StandardAnalyzer());
+        mergePolicy = new MergePolicy() {
+            // This anonymous MergePolicy stub is used only for unit testing
+            @Override
+            public MergeSpec findMerges(List<SegmentMetadata> segments) {
+                return null;
+            }
+        };
+        config = new IndexWriterConfig(analyzer, mergePolicy, 10); // maxBufferedDocs = 10
+        writer = new IndexWriter(storage, config);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        if (writer != null) {
+            writer.close();
+        }
+    }
+
+    private Document createTestDocument(int id, String content) {
+        Document doc = new Document(id);
+        doc.addField("content", content);
+        return doc;
+    }
+
+    @Test
+    void shouldCreateSegmentFilesAndNotCommitFiles_WhenFlushIsSuccessful() throws IOException {
+        // Given
+        writer.addDocument(createTestDocument(1, "First document"));
+        writer.addDocument(createTestDocument(2, "Second document"));
+
+        // When
+        writer.flush();
+
+        // Then
+        // Check that segment files were created
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.DOC.getExtension())), "segment_0.doc should exist");
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.POST.getExtension())), "segment_0.post should exist");
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.DIC.getExtension())), "segment_0.dic should exist");
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.META.getExtension())), "segment_0.meta should exist");
+
+        // Check that commit point files were NOT created yet, as commit() was not called
+        assertFalse(Files.exists(tempDir.resolve("segments_0")), "segments_0 should not exist before commit");
+        assertFalse(Files.exists(tempDir.resolve(Segments.SEGMENTS_GEN)), "segments.gen should not exist before commit");
+    }
+
+    @Test
+    void shouldCreateCommitPointFiles_WhenCommitIsSuccessful() throws IOException {
+        // Given
+        writer.addDocument(createTestDocument(1, "A document to commit"));
+
+        // When
+        writer.commit();
+
+        // Then
+        // Check that segment files were created
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.DOC.getExtension())), "segment_0.doc should exist");
+
+        // Check that commit point files were created
+        assertTrue(Files.exists(tempDir.resolve("segments_0")), "segments_0 should exist after commit");
+        assertTrue(Files.exists(tempDir.resolve(Segments.SEGMENTS_GEN)), "segments.gen should exist after commit");
+
+        // Verify the content of segments.gen
+        String genContent = Files.readString(tempDir.resolve(Segments.SEGMENTS_GEN));
+        assertEquals("0", genContent.trim(), "segments.gen should contain '0'");
+    }
+
+    @Test
+    void shouldCleanupPartialSegmentFiles_WhenFlushFails() {
+        // Given
+        Storage faultyStorage = new FaultyStorage(tempDir);
+        Exception thrownException = null;
+
+        try (IndexWriter faultyWriter = new IndexWriter(faultyStorage, config)) {
+            faultyWriter.addDocument(createTestDocument(1, "This flush should fail"));
+            faultyWriter.flush(); // This call is expected to throw an IOException
+        } catch (IOException e) {
+            thrownException = e;
+        }
+
+        // Then
+        assertNotNull(thrownException, "An IOException should have been thrown during flush.");
+        assertTrue(thrownException.getMessage().contains("Failed to flush segment segment_0"), "Exception message should indicate flush failure.");
+
+        // Assert that all potential segment files were cleaned up
+        assertFalse(Files.exists(tempDir.resolve("segment_0" + FileType.DOC.getExtension())), "Partial .doc file should be cleaned up.");
+        assertFalse(Files.exists(tempDir.resolve("segment_0" + FileType.POST.getExtension())), "Partial .post file should be cleaned up.");
+        assertFalse(Files.exists(tempDir.resolve("segment_0" + FileType.DIC.getExtension())), "Partial .dic file should be cleaned up.");
+        assertFalse(Files.exists(tempDir.resolve("segment_0" + FileType.META.getExtension())), "Partial .meta file should be cleaned up.");
+    }
+
+    @Test
+    void shouldInitializeSegmentCounterCorrectly_WhenOpeningExistingIndex() throws IOException {
+        // Given: An existing index with one segment committed
+        writer.addDocument(createTestDocument(1, "doc1 for first writer"));
+        writer.commit();
+        writer.close(); // Close the first writer to simulate a restart, this also closes the storage
+
+        // When: A new writer is created on the same directory
+        Storage newStorage = new FileSystemStorage(tempDir);
+        IndexWriter newWriter = new IndexWriter(newStorage, config);
+
+        // Add a new document and flush to verify a new segment is created with the correct name
+        newWriter.addDocument(createTestDocument(2, "doc2 for second writer"));
+        newWriter.flush();
+
+        // Assert that the new segment is segment_1, which reflects the segmentCounter field
+        assertTrue(Files.exists(tempDir.resolve("segment_1" + FileType.DOC.getExtension())), "segment_1.doc should exist");
+        newWriter.close();
+    }
+
+    @Test
+    void shouldAutomaticallyFlushDocuments_WhenMaxBufferedDocsIsReached() throws IOException {
+        // Given: A config with maxBufferedDocs = 2
+        config = new IndexWriterConfig(analyzer, mergePolicy, 2);
+        writer.close(); // Close the old writer to apply new config, this also closes the storage
+        Storage newStorage = new FileSystemStorage(tempDir);
+        writer = new IndexWriter(newStorage, config);
+
+        // When: We add exactly maxBufferedDocs documents
+        writer.addDocument(createTestDocument(1, "doc1"));
+        writer.addDocument(createTestDocument(2, "doc2")); // This second addDocument() call should trigger flush()
+
+        // Then: Segment files for segment_0 should exist without an explicit flush() call
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.DOC.getExtension())), "segment_0.doc should exist due to auto-flush");
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.POST.getExtension())), "segment_0.post should exist due to auto-flush");
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.DIC.getExtension())), "segment_0.dic should exist due to auto-flush");
+        assertTrue(Files.exists(tempDir.resolve("segment_0" + FileType.META.getExtension())), "segment_0.meta should exist due to auto-flush");
+    }
+
+    @Test
+    void shouldNotFlush_WhenDocumentBufferIsEmpty() throws IOException {
+        // Given: An empty document buffer
+        // When: flush() is called
+        writer.flush();
+
+        // Then: No segment files should be created
+        assertFalse(Files.exists(tempDir.resolve("segment_0" + FileType.DOC.getExtension())), "No segment files should be created for empty buffer");
+        assertFalse(Files.exists(tempDir.resolve(Segments.SEGMENTS_GEN)), "No commit files should be created for empty buffer");
+    }
+
+    @Test
+    void shouldThrowNullPointerException_WhenAnalyzerIsNullInConfig() throws IOException {
+        // Given: A null analyzer is to be used
+        writer.close(); // Close current writer to release resources
+
+        // When & Then: Creating an IndexWriterConfig with a null analyzer should throw NullPointerException
+        assertThrows(NullPointerException.class, () -> {
+            new IndexWriterConfig(null, mergePolicy, 10);
+        }, "IndexWriterConfig constructor should throw NullPointerException if analyzer is null.");
+    }
+
+
+    /**
+     * A custom Storage implementation that throws an exception during the creation
+     * of the second file writer (.post) to simulate a failure during flush.
+     */
+    private static class FaultyStorage extends FileSystemStorage {
+        private boolean firstDocWriterCreated = false;
+
+        public FaultyStorage(Path rootPath) {
+            super(rootPath);
+        }
+
+        @Override
+        public SegmentFileWriter createFileWriter(String name, FileType type) throws IOException {
+            // Allow the .doc file to be created successfully
+            if (type == FileType.DOC && !firstDocWriterCreated) {
+                firstDocWriterCreated = true;
+                return super.createFileWriter(name, type);
+            }
+            // Fail on the next file type (.post)
+            if (type == FileType.POST) {
+                throw new IOException("Simulated I/O error on creating .post file");
+            }
+            return super.createFileWriter(name, type);
+        }
+    }
+}


### PR DESCRIPTION
# Implement IndexWriter flush() and commit()

## Overview

This pull request implements the core data persistence logic for the search index by fully implementing the `flush()` and `commit()` methods in `IndexWriter`. It introduces a robust commit point mechanism to ensure that the index state is durable and recoverable.

The previous `IndexWriter` could only buffer documents in memory. These changes enable it to write those documents to persistent segment files and safely update the index's state to make those segments searchable.

## Reason for change

This change implements the fundamental persistence layer of the search engine. Without it, no indexed data would survive beyond the life of the `IndexWriter` object. This is a critical step toward creating a functional and durable index.

## Key Changes

-   **`IndexWriter` Implementation & Refactoring:**
    -   The `flush()` method has been fully implemented to orchestrate the segment creation pipeline: analyzing documents, building an in-memory inverted index, and writing segment files (`.doc`, `.post`, `.dic`, `.meta`).
    -   The method has been refactored into smaller, private helpers (`buildInMemoryIndex`, `writeSegmentData`, `registerNewSegment`) for improved readability and maintainability.
    -   Parameter objects (`SegmentWriters`, `SegmentFiles`, `InMemoryIndex`) have been introduced to create cleaner method signatures.

-   **Commit Point Management (`Segments.java`):**
    -   A new `Segments` class has been added to manage the state of the index's segments.
    -   It provides crash-safe semantics by using a generation file (`segments.gen`) to atomically update a `segments_N` file, which contains the list of all active segments in the index.
    -   `IndexWriter` now uses this class to load the last known state on startup and to commit new segments.

-   **`Storage` Interface Update:**
    -   The `Storage` abstract class has been updated with `createFileWriter` and `createMetaFileWriter` methods to support the writing process.

## Tests

-   **Comprehensive Testing (`IndexWriterTest.java`):**
    -  A new, thorough test suite for `IndexWriter` has been added.
    -  Tests cover the full `flush` and `commit` lifecycle, including successful writes, state recovery after restarting the writer, and auto-flushing.
    -  A `FaultyStorage` mock is used to test the critical error handling and file cleanup logic, ensuring that partial segments are removed on failure.
    -  For there is no `MergePolicy` interface implemented class, using anonymous class instance as a stub.